### PR TITLE
[Issue #7] Update to docker-java 3.2.0-rc5

### DIFF
--- a/gradle/artifacts.gradle
+++ b/gradle/artifacts.gradle
@@ -40,6 +40,9 @@ shadowJar {
     packagesToRelocate.each { pkg ->
         relocate pkg, "${basePackage}.${pkg}"
     }
+    // Keep this uber JAR free of java 9 and java 11 modules for now
+    exclude 'module-info.class'
+    exclude 'META-INF/versions/**'
 }
 
 jar {

--- a/gradle/projects.gradle
+++ b/gradle/projects.gradle
@@ -20,7 +20,11 @@ allprojects {
     }
 
     dependencies {
-        dockerJava group: 'com.github.docker-java', name: 'docker-java', version: '3.1.2'
+        dockerJava group: 'com.github.docker-java', name: 'docker-java', version: '3.2.0-rc5'
+        // Update to latest jersey as well, had some Java 12 in 2.30
+        dockerJava 'org.glassfish.jersey.connectors:jersey-apache-connector:2.30.1'
+        dockerJava 'org.glassfish.jersey.core:jersey-client:2.30.1'
+        dockerJava 'org.glassfish.jersey.inject:jersey-hk2:2.30.1'
     }
 
     tasks.withType(JavaCompile) {


### PR DESCRIPTION
Motivation:

Solving the docker-java issue https://github.com/docker-java/docker-java/issues/698#issuecomment-572228590

Modification:

update version of docker-java to 3.2.0-rc5
filter shadow JAR to exclude module-info.class and META-INF/versions/**

Result:

Fixes #7 
